### PR TITLE
Update news migrations with the field_theme_s_ field.

### DIFF
--- a/config/default/migrate_plus.migration.iied_d7_news_media.yml
+++ b/config/default/migrate_plus.migration.iied_d7_news_media.yml
@@ -171,6 +171,12 @@ process:
       bundle_key: vid
       value_key: name
       ignore_case: true
+  field_theme_s_:
+    -
+      plugin: sub_process
+      source: taxonomy_vocabulary_19
+      process:
+        target_id: tid
 destination:
   plugin: 'entity_complete:node'
   translations: true

--- a/config/default/migrate_plus.migration.iied_d7_news_press.yml
+++ b/config/default/migrate_plus.migration.iied_d7_news_press.yml
@@ -105,6 +105,12 @@ process:
       bundle_key: vid
       value_key: name
       ignore_case: true
+  field_theme_s_:
+    -
+      plugin: sub_process
+      source: taxonomy_vocabulary_19
+      process:
+        target_id: tid
 destination:
   plugin: 'entity_complete:node'
   translations: true

--- a/docroot/modules/custom/iied_migrate_d7/README.md
+++ b/docroot/modules/custom/iied_migrate_d7/README.md
@@ -78,3 +78,26 @@ You can try running the whole group with:
 ```bash
 lando drush mim --group=iied_migrate_d7
 ```
+
+## Importing changes to the migrations
+
+The migration configuration is stored in the config/install folder. When we
+make changes to the config there, we need to import it into the active config
+before exporting it to the default. One was to do this is as follows:
+
+```
+lando drush config-import --partial --source=modules/custom/iied_migrate_d7/config/install
+```
+
+## Run an update migration for news
+
+Once we've made changes to a migration config that has already run, we might
+want to run an update migration. To do this we can append --update to the
+migration import command.
+
+```
+lando drush mim iied_d7_news_press --update
+```
+
+In this case, we should be able to migrate the themes to the field_theme_s_
+field that got missed.

--- a/docroot/modules/custom/iied_migrate_d7/config/install/migrate_plus.migration.iied_d7_news_media.yml
+++ b/docroot/modules/custom/iied_migrate_d7/config/install/migrate_plus.migration.iied_d7_news_media.yml
@@ -171,6 +171,12 @@ process:
       bundle_key: vid
       value_key: name
       ignore_case: true
+  field_theme_s_:
+    -
+      plugin: sub_process
+      source: taxonomy_vocabulary_19
+      process:
+        target_id: tid
 destination:
   plugin: 'entity_complete:node'
   translations: true

--- a/docroot/modules/custom/iied_migrate_d7/config/install/migrate_plus.migration.iied_d7_news_press.yml
+++ b/docroot/modules/custom/iied_migrate_d7/config/install/migrate_plus.migration.iied_d7_news_press.yml
@@ -104,6 +104,12 @@ process:
       bundle_key: vid
       value_key: name
       ignore_case: true
+  field_theme_s_:
+    -
+      plugin: sub_process
+      source: taxonomy_vocabulary_19
+      process:
+        target_id: tid
 destination:
   plugin: 'entity_complete:node'
   translations: true


### PR DESCRIPTION
Address https://github.com/IIED-org/IIED-main/issues/395 

Add the migration mappings to the field_theme_s_ field.

Should then be able to run: 

```
lando drush mim iied_d7_news_media --update
lando drush mim iied_d7_news_press --update
```

But I guess we might need to copy the db down, run the migration, then copy it back up again.